### PR TITLE
Improve unit compatibility and enable statistics

### DIFF
--- a/custom_components/weatherxm/battery.py
+++ b/custom_components/weatherxm/battery.py
@@ -1,5 +1,11 @@
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.components.sensor import SensorEntity
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 
 BATTERY_LEVEL_MAP = {
     "ok": 100.0,
@@ -16,6 +22,8 @@ class WeatherXMBatteryLevelSensor(CoordinatorEntity, SensorEntity):
         self._is_active = is_active
         self._attr_name = f"{alias} Battery"
         self._attr_unique_id = f"{alias}_battery"
+        self._attr_state_class = SensorDeviceClass.BATTERY
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def state(self):

--- a/custom_components/weatherxm/rewards.py
+++ b/custom_components/weatherxm/rewards.py
@@ -1,5 +1,11 @@
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.components.sensor import SensorEntity
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 
 class WeatherXMRewardsSensor(CoordinatorEntity, SensorEntity):
     def __init__(self, coordinator, device_id, alias, actual_reward, total_rewards):
@@ -10,6 +16,7 @@ class WeatherXMRewardsSensor(CoordinatorEntity, SensorEntity):
         self._total_rewards = total_rewards
         self._attr_name = f"{alias} Rewards"
         self._attr_unique_id = f"{alias}_rewards"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
     def state(self):
@@ -37,6 +44,7 @@ class WeatherXMTotalRewardsSensor(CoordinatorEntity, SensorEntity):
         self._total_rewards = total_rewards
         self._attr_name = f"{alias} Total Rewards"
         self._attr_unique_id = f"{alias}_total_rewards"
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
     def state(self):

--- a/custom_components/weatherxm/weather.py
+++ b/custom_components/weatherxm/weather.py
@@ -134,11 +134,11 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         return self._current_weather.get("humidity")
 
     @property
-    def precipitation(self):
+    def native_precipitation(self):
         return self._current_weather.get("precipitation")
 
     @property
-    def precipitation_accumulated(self):
+    def native_precipitation_accumulated(self):
         return self._current_weather.get("precipitation_accumulated")
 
     @property
@@ -192,17 +192,17 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
             "apparent_temperature": self.apparent_temperature,
             "condition": self.condition,
             "datetime": self.datetime,
-            "dew_point": self.dew_point,
+            "native_dew_point": self.native_dew_point,
             "humidity": self.humidity,
-            "precipitation": self.precipitation,
-            "precipitation_accumulated": self.precipitation_accumulated,
-            "pressure": self.pressure,
+            "native_precipitation": self.native_precipitation,
+            "native_precipitation_accumulated": self.native_precipitation_accumulated,
+            "native_pressure": self.native_pressure,
             "solar_irradiance": self.solar_irradiance,
-            "temperature": self.temperature,
+            "native_temperature": self.native_temperature,
             "uv_index": self.uv_index,
             "wind_bearing": self.wind_bearing,
-            "wind_speed": self.wind_speed,
-            "wind_gust_speed": self.wind_gust_speed,
+            "native_wind_speed": self.native_wind_speed,
+            "native_wind_gust_speed": self.native_wind_gust_speed,
         })
         return data
 

--- a/custom_components/weatherxm/weather.py
+++ b/custom_components/weatherxm/weather.py
@@ -220,10 +220,10 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
             for hourly in daily.get("hourly", []):
                 hourly_forecast = {
                     "datetime": hourly.get("timestamp"),
-                    "temperature": hourly.get("temperature"),
-                    "precipitation": hourly.get("precipitation"),
+                    "native_temperature": hourly.get("temperature"),
+                    "native_precipitation": hourly.get("precipitation"),
                     "precipitation_probability": hourly.get("precipitation_probability"),
-                    "wind_speed": hourly.get("wind_speed"),
+                    "native_wind_speed": hourly.get("wind_speed"),
                     "wind_bearing": hourly.get("wind_direction"),
                     "condition": ICON_TO_CONDITION_MAP.get(hourly.get("icon"), "unknown"),
                 }
@@ -237,11 +237,11 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
             day_data = daily.get("daily", {})
             daily_forecast = {
                 "datetime": day_data.get("timestamp"),
-                "temperature": day_data.get("temperature_max"),
-                "templow": day_data.get("temperature_min"),
-                "precipitation": day_data.get("precipitation_intensity"),
+                "native_temperature": day_data.get("temperature_max"),
+                "native_templow": day_data.get("temperature_min"),
+                "native_precipitation": day_data.get("precipitation_intensity"),
                 "precipitation_probability": day_data.get("precipitation_probability"),
-                "wind_speed": day_data.get("wind_speed"),
+                "native_wind_speed": day_data.get("wind_speed"),
                 "wind_bearing": day_data.get("wind_direction"),
                 "condition": ICON_TO_CONDITION_MAP.get(day_data.get("icon"), "unknown"),
             }

--- a/custom_components/weatherxm/weather.py
+++ b/custom_components/weatherxm/weather.py
@@ -126,7 +126,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         return self._current_weather.get("timestamp")
 
     @property
-    def dew_point(self):
+    def native_dew_point(self):
         return self._current_weather.get("dew_point")
 
     @property
@@ -142,7 +142,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         return self._current_weather.get("precipitation_accumulated")
 
     @property
-    def pressure(self):
+    def native_pressure(self):
         return self._current_weather.get("pressure")
 
     @property
@@ -150,7 +150,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         return self._current_weather.get("solar_irradiance")
 
     @property
-    def temperature(self):
+    def native_temperature(self):
         return self._current_weather.get("temperature")
 
     @property
@@ -162,11 +162,11 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         return self._current_weather.get("wind_direction")
 
     @property
-    def wind_gust_speed(self):
+    def native_wind_gust_speed(self):
         return self._current_weather.get("wind_gust")
 
     @property
-    def wind_speed(self):
+    def native_wind_speed(self):
         return self._current_weather.get("wind_speed")
 
     async def async_update(self):

--- a/custom_components/weatherxm/weather.py
+++ b/custom_components/weatherxm/weather.py
@@ -111,7 +111,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         self._attr_unique_id = alias
 
     @property
-    def apparent_temperature(self):
+    def native_apparent_temperature(self):
         return self._current_weather.get("feels_like")
 
     @property
@@ -189,7 +189,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
         """Return the state attributes."""
         data = super().state_attributes
         data.update({
-            "apparent_temperature": self.apparent_temperature,
+            "native_apparent_temperature": self.native_apparent_temperature,
             "condition": self.condition,
             "datetime": self.datetime,
             "native_dew_point": self.native_dew_point,

--- a/custom_components/weatherxm/weather.py
+++ b/custom_components/weatherxm/weather.py
@@ -92,7 +92,7 @@ class WeatherXMWeather(CoordinatorEntity, WeatherEntity):
 
     _attr_native_precipitation_unit = UnitOfPrecipitationDepth.MILLIMETERS
     _attr_native_pressure_unit = UnitOfPressure.HPA
-    _attr_native_wind_speed_unit = UnitOfSpeed.KILOMETERS_PER_HOUR
+    _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
     _attr_supported_features = (
         WeatherEntityFeature.FORECAST_DAILY | WeatherEntityFeature.FORECAST_HOURLY
     )


### PR DESCRIPTION
Hi, nice work for a first integration! This PR corrects a few things to allow easier use in different unit systems, by switching many of the variables to the `native` version, meaning it specifies that the value is in the native unit given in the config, which fixes unit conversion for Fahrenheit, inHg, etc. I also fixed the native wind speed unit (m/s, rather than kph).

I also added StateClass and DeviceClass to the battery and rewards sensors, this allows for proper statistics usage, and particularly for the total rewards sensors, would allow for nicer graphs showing change over time.

I'm playing with the automatic update thing, but I can't figure out why it isn't working either - everything seems to be there from other working examples I've seen... If I figure it out I'll submit another PR.